### PR TITLE
(SIMP-8354) Populate metadata.json "summary" field

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "simp-crypto_policy",
   "version": "0.1.0",
   "author": "SIMP Team",
-  "summary": "",
+  "summary": "Manage, and provide information about, the system-wide crypto policies",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-crypto_policy",
   "dependencies": [


### PR DESCRIPTION
This patch adds content to the empty "summary" field in metadata.json,
which had been causing the Puppet Forge to reject the module.

[SIMP-8354] #close

[SIMP-8354]: https://simp-project.atlassian.net/browse/SIMP-8354