### PR TITLE
(SIMP-8815) Fix list of available policies

### DIFF
--- a/lib/facter/crypto_policy__state.rb
+++ b/lib/facter/crypto_policy__state.rb
@@ -35,7 +35,7 @@ Facter.add('crypto_policy__state') do
 
       system_state['global_policy_applied'] = !Array(output).grep(%r{is applied}).empty? if output
 
-      system_state['global_policies_available'] = Dir.glob('/usr/share/crypto-policies/*').select { |x| File.directory?(x) }.map { |x| File.basename(x) }
+      system_state['global_policies_available'] = Dir.glob('/usr/share/crypto-policies/policies/*.pol').select { |x| File.file?(x) }.map { |x| File.basename(x).sub(%r{\.pol$}, '') }
     end
 
     system_state


### PR DESCRIPTION
Glob the `*.pol` files in `/usr/share/crypto-policies/policies/` instead of the directories in `/usr/share/crypto-policies/` to get the list of available policies for the `crypto_policy__state.global_policies_available` fact.

SIMP-8815 #close