### PR TITLE
(SIMP-8839) Install a minimum package version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Thu Dec 24 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.3-0
-- Add support for Puppet 8
+- Ensure that the crypto-policy version is at a non-fatal bug level
+- Add support for Puppet 7
 - Fixed error string in main class
 
 * Tue Oct 20 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2-0

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -79,7 +79,10 @@ Data type: `String[1]`
 
 The 'ensure' parameter for `$packages`
 
-Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
+* NOTE: There are issues with `crypto-policies < 20190000` which may render
+  a FIPS system inaccessible.
+
+Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => '>20190000' })`
 
 ### `crypto_policy::update`
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,11 +6,14 @@
 # @param package_ensure
 #   The 'ensure' parameter for `$packages`
 #
+#   * NOTE: There are issues with `crypto-policies < 20190000` which may render
+#     a FIPS system inaccessible.
+#
 # @author https://github.com/simp/pupmod-simp-crypto_policy/graphs/contributors
 #
 class crypto_policy::install (
   Array[String[1]] $packages       = ['crypto-policies'],
-  String[1]        $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
+  String[1]        $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => '>20190000' })
 ) {
   assert_private()
 


### PR DESCRIPTION
The version of the crypto-policies package that shipped with EL8.0 will
cause systems to become inaccessible once placed into FIPS mode.

SIMP-8839 #comment update crypto-policies package version