### PR TITLE
(SIMP-9780) Puppetsync: Remove Puppet 5, Support 7

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -11,13 +11,11 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# SIMP 6.4      5.5      2.40    TBD
-# PE 2018.1     5.5      2.40    2021-01 (LTS overlap)
-# PE 2019.8     6.18     2.5     2022-12 (LTS)
+# PE 2019.8     6.22     2.5     2022-12 (LTS)
+# PE 2021.Y     7.x      2.7     Quarterly updates
 #
-# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
-# https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ==============================================================================
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
@@ -111,12 +109,9 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 6.18 [SIMP 6.5/PE 2019.8]'
-            puppet_version: '~> 6.18.0'
+          - label: 'Puppet 6.22 [SIMP 6.6/PE 2019.8]'
+            puppet_version: '~> 6.22.1'
             ruby_version: '2.5'
-          - label: 'Puppet 5.5 [SIMP 6.4/PE 2018.1]'
-            puppet_version: '~> 5.5.22'
-            ruby_version: '2.4'
           - label: 'Puppet 7.x'
             puppet_version: '~> 7.0'
             ruby_version: '2.7'

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist
 /.rspec_system
 /.vagrant
 /.bundle
+/.vendor
 /vendor
 /junit
 /log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,9 +13,7 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# SIMP 6.4      5.5      2.4.10  TBD
-# PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
-# PE 2019.8     6.18     2.5.7   2022-12 (LTS)
+# PE 2019.8     6.22     2.5.7   2022-12 (LTS)
 ---
 
 stages:
@@ -32,7 +30,7 @@ variables:
   # anchors.  If it is still `UNDEFINED`, all the other setting from the job's
   # anchor are also missing.
   PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
-  BUNDLER_VERSION:   '1.17.1'
+  BUNDLER_VERSION:   '2.2.19'
   SIMP_MATRIX_LEVEL: '1'
   SIMP_FORCE_RUN_MATRIX: 'no'
 
@@ -224,20 +222,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5_x: &pup_5_x
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '~> 5.0'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
-.pup_5_pe: &pup_5_pe
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '5.5.22'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
 .pup_6_x: &pup_6_x
   image: 'ruby:2.5'
   variables:
@@ -248,7 +232,7 @@ variables:
 .pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '6.18.0'
+    PUPPET_VERSION: '6.22.1'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -299,7 +283,7 @@ releng_checks:
   <<: *pup_6_x
   <<: *setup_bundler_env
   stage: 'validation'
-  tags: ['docker', 'shared']
+  tags: ['docker']
   script:
     - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
     - 'bundle exec rake check:dot_underscore'
@@ -307,7 +291,6 @@ releng_checks:
     - 'bundle exec rake pkg:check_version'
     - 'bundle exec rake pkg:compare_latest_tag'
     - 'bundle exec rake pkg:create_tag_changelog'
-    - 'bundle exec env | grep ^PATH'
     - 'bundle exec pdk build --force --target-dir=dist'
 
 
@@ -325,15 +308,6 @@ pup-lint:
 
 # Unit Tests
 #-----------------------------------------------------------------------
-
-pup5.x-unit:
-  <<: *pup_5_x
-  <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
-
-pup5.pe-unit:
-  <<: *pup_5_pe
-  <<: *unit_tests
 
 pup6.x-unit:
   <<: *pup_6_x
@@ -357,12 +331,6 @@ pup7.x-unit:
 
 # Repo-specific content
 # ==============================================================================
-
-pup5.x:
-  <<: *pup_5_x
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites[default]'
 
 pup6.x:
   <<: *pup_6_x

--- a/.pdkignore
+++ b/.pdkignore
@@ -1,3 +1,13 @@
+# .pdkignore masks files from inclusion by `pdk build`.
+#
+# It is used by CI when building modules to publish to the Puppet Forge and to
+# mask symlinks from the `pdk build` test in the module's RELENG checks.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 .*.sw?
 .git/
 .metadata

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Jun 15 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.2.0
+- Removed support for Puppet 5
+- Ensured support for Puppet 7 in requirements and stdlib
+
 * Thu Jan 21 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.5
 - Move the crypto_policy__state fact into simplib for use by other modules
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib
 
-* Thu Jan 21 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.5
+* Thu Jan 21 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.0
 - Move the crypto_policy__state fact into simplib for use by other modules
 
 * Fri Jan 01 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.4-0

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version
@@ -24,7 +24,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.11.5', '< 6']
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
@@ -38,7 +38,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.4', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-crypto_policy",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "author": "SIMP Team",
   "summary": "Manage, and provide information about, the system-wide crypto policies",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 6.18.0 < 8.0.0"
     },
     {
       "name": "simp/simplib",
@@ -47,7 +47,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 6.22.1 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
This patch:

  * Removes Puppet 5 from `metadata.json` and the GHA & GLCI matrix
  * Ensures support for Puppet 7 in `metadata.json`
    * Ensures Pup 7 for module deps stdlib and concat (if present)
  * Updates GLCI and GHA matrix to model Puppet PE using Puppet 6.22.1
  * Bumps Gemfile's simp-rake-helpers and simp-beaker-helpers min vers
  * Removes `.pmtignore` and adds `.pdkignore`

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.

[SIMP-9795] #close
[SIMP-9780] #comment Drop Puppet 5 in pupmod-simp-crypto_policy
[SIMP-9670] #comment update Puppet 6.22.1 in pupmod-simp-crypto_policy
[SIMP-9606] #comment Switch pupmod-simp-crypto_policy from .pmtignore to .pdkignore
[SIMP-9781] #comment bump Gemfile versons in pupmod-simp-crypto_policy

[SIMP-9795]: https://simp-project.atlassian.net/browse/SIMP-9795
[SIMP-9780]: https://simp-project.atlassian.net/browse/SIMP-9780
[SIMP-9670]: https://simp-project.atlassian.net/browse/SIMP-9670
[SIMP-9606]: https://simp-project.atlassian.net/browse/SIMP-9606
[SIMP-9781]: https://simp-project.atlassian.net/browse/SIMP-9781