### PR TITLE
Cleanup for 3.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake parallel_spec'
+      - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:
@@ -119,8 +119,20 @@ jobs:
     strategy:
       matrix:
         node:
-          - almalinux9
-          - almalinux10
+          - docker_alma8
+          - docker_alma9
+          - docker_alma10
+          - docker_centos9
+          - docker_centos10
+          - docker_oel8
+          - docker_oel9
+          - docker_oel10
+          - docker_rhel8
+          - docker_rhel9
+          - docker_rhel10
+          - docker_rocky8
+          - docker_rocky9
+          - docker_rocky10
       fail-fast: false
     steps:
       - name: checkout repo
@@ -132,15 +144,10 @@ jobs:
       - name: bundle install
         run: |
           bundle install
-      - name: Setup libvirt for Vagrant
+      - name: Setup podman
         run: |
-          sudo add-apt-repository ppa:evgeni/vagrant
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-daemon-system libvirt-daemon qemu-system-x86 qemu-utils dnsmasq
-          sudo chmod 666 /var/run/libvirt/libvirt-sock
+          systemctl start --user podman.socket
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
       - name: beaker
-        env:
-          BEAKER_HYPERVISOR: 'vagrant_libvirt'
-          VAGRANT_DEFAULT_PROVIDER: 'libvirt'
         run: |
           bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -8,21 +8,11 @@
 #
 # ==============================================================================
 #
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5     2022-12 (LTS)
-# PE 2021.Y     7.x      2.7     Quarterly updates
-#
-# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# ==============================================================================
-#
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -35,7 +25,7 @@ jobs:
       - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 3.2
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -47,7 +37,7 @@ jobs:
       - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -58,10 +48,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - name: "Install Ruby 3.2"
+      - name: "Install Ruby 3.4"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: |
           bundle show
@@ -72,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: 'Install Ruby 3.2'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -85,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: 'Install Ruby 3.2'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -105,10 +95,6 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
@@ -124,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:
@@ -133,20 +119,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - docker_alma8
-          - docker_alma9
-          - docker_alma10
-          - docker_centos9
-          - docker_centos10
-          - docker_oel8
-          - docker_oel9
-          - docker_oel10
-          - docker_rhel8
-          - docker_rhel9
-          - docker_rhel10
-          - docker_rocky8
-          - docker_rocky9
-          - docker_rocky10
+          - almalinux9
+          - almalinux10
       fail-fast: false
     steps:
       - name: checkout repo
@@ -154,14 +128,19 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4.9
       - name: bundle install
         run: |
           bundle install
-      - name: Setup podman
+      - name: Setup libvirt for Vagrant
         run: |
-          systemctl start --user podman.socket
-          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+          sudo add-apt-repository ppa:evgeni/vagrant
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-daemon-system libvirt-daemon qemu-system-x86 qemu-utils dnsmasq
+          sudo chmod 666 /var/run/libvirt/libvirt-sock
       - name: beaker
+        env:
+          BEAKER_HYPERVISOR: 'vagrant_libvirt'
+          VAGRANT_DEFAULT_PROVIDER: 'libvirt'
         run: |
           bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 3.0.0
+- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
+- Point `issues_url` at GitHub Issues
+- Drop end-of-life OS support (CentOS 8, EL7); list EL10 across all supported distros
+- Allow newer SIMP module dependencies (see metadata.json diff)
+- Sync Gemfile with current puppetsync baseline (adds OpenVox to test gems)
+- Drop Puppet 7 / Ruby 2.7 from GitHub Actions; use Ruby 3.2.11 with OpenVox 8 and 3.4.9 elsewhere
+
 * Tue May 12 2026 Steven Pritchard <steve@sicura.us> - 2.0.4
 - Add Oracle Linux 10 and Rocky Linux 10 support
 - Switch default acceptance nodeset to EL10 (Rocky 10)

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem_sources.each { |gem_source| source gem_source }
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.86.0'
+  gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake', '~> 0.7.0'
   gem 'rubocop-rspec', '~> 3.9.0'

--- a/Gemfile
+++ b/Gemfile
@@ -13,20 +13,23 @@ gem_sources.each { |gem_source| source gem_source }
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.87.0'
+  gem 'rubocop', '~> 1.86.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake', '~> 0.7.0'
   gem 'rubocop-rspec', '~> 3.9.0'
 end
 
 group :test do
-  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
+  openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
   major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
   gem 'hiera-puppet-helper'
-  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   # renovate: datasource=rubygems versioning=ruby
   gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  gem 'puppet', puppet_version
+  # Temporarily include both openvox and puppet gems until the puppet dependency is removed from other gems
+  ['openvox', 'puppet'].each do |gem_name|
+    gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
+  end
   gem 'puppetlabs_spec_helper', '~> 8.0.0'
   gem 'puppet-strings'
   gem 'rake'
@@ -36,6 +39,7 @@ group :test do
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.24.0')
   # renovate: datasource=rubygems versioning=ruby
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
+  gem 'syslog', require: false
 end
 
 group :development do
@@ -47,7 +51,6 @@ end
 group :system_tests do
   gem 'bcrypt_pbkdf'
   gem 'beaker'
-  gem 'beaker_puppet_helpers'
   gem 'beaker-rspec'
   # renovate: datasource=rubygems versioning=ruby
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 2.0.0')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-crypto_policy",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "author": "SIMP Team",
   "summary": "Manage, and provide information about, the system-wide crypto policies",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
       ]
     },
     {
-      "operatingsystem": "OracleLinux",
+      "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "8",
         "9",
@@ -37,7 +37,7 @@
       ]
     },
     {
-      "operatingsystem": "RedHat",
+      "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "8",
         "9",
@@ -63,8 +63,9 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
-  ]
+  ],
+  "issues_url": "https://github.com/simp/pupmod-simp-crypto_policy/issues"
 }

--- a/spec/acceptance/nodesets/almalinux10.yml
+++ b/spec/acceptance/nodesets/almalinux10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: almalinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux8.yml
+++ b/spec/acceptance/nodesets/almalinux8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: almalinux/8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux9.yml
+++ b/spec/acceptance/nodesets/almalinux9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: almalinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos10.yml
+++ b/spec/acceptance/nodesets/centos10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/centos10s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel10.yml
+++ b/spec/acceptance/nodesets/oel10.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/oracle10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel10.yml
+++ b/spec/acceptance/nodesets/rhel10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/rhel10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky10.yml
+++ b/spec/acceptance/nodesets/rocky10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: rockylinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"


### PR DESCRIPTION
## Summary

Cleanup pass to bring this module in line with the current SIMP baseline. No API/behavior changes.

- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
- Point `issues_url` at GitHub Issues
- Drop end-of-life OS support (CentOS 8, EL7); list EL10 across all supported distros
- Allow newer SIMP module dependencies (see metadata.json diff)
- Sync Gemfile with current puppetsync baseline (adds OpenVox to test gems)
- Drop Puppet 7 / Ruby 2.7 from GitHub Actions; use Ruby 3.2.11 with OpenVox 8 and 3.4.9 elsewhere

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)
