### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -12,6 +12,27 @@ describe 'crypto_policy class' do
   end
 
   hosts.each do |host|
+    # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+    # console previews the module with `puppet apply --noop`, which must not error
+    # even though nothing crypto_policy manages exists yet. Real idempotence is covered
+    # by the applies below. A post-convergence noop check is deliberately omitted:
+    # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+    # fail and would test nothing.
+    context 'in noop mode from a clean state' do
+      # Setup, not an assertion: as before(:context) a failure errors this context
+      # rather than aborting the whole suite under .rspec's --fail-fast. `puppet
+      # resource` exits 0 whether it removes the package or finds it already absent
+      # (no --detailed-exitcodes), so no acceptable_exit_codes override is needed.
+      before(:context) do
+        on(host, 'puppet resource package crypto-policies ensure=absent')
+        on(host, 'puppet resource package crypto-policies-scripts ensure=absent')
+      end
+
+      it 'applies without errors in noop mode' do
+        apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+      end
+    end
+
     if pfact_on(host, 'fips_enabled')
       let(:default_policy) { 'FIPS' }
     else


### PR DESCRIPTION
Adds an acceptance example that applies the module under `puppet apply --noop` from a fresh, uninstalled node — mirroring the preview the Sicura console runs on a clean host — and asserts it completes without error. It reuses the suite's existing default manifest so the check stays representative of the module's real default, and deliberately omits a post-convergence noop check (`--noop --detailed-exitcodes` always exits 0, so it would test nothing).