### PR TITLE
Add a REFERENCE.md freshness check to PR tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -70,6 +70,24 @@ jobs:
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
 
+  reference:
+    name: 'REFERENCE.md freshness'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - name: 'Regenerate REFERENCE.md and fail on drift'
+        run: |
+          bundle exec rake strings:generate:reference
+          git diff --exit-code -- REFERENCE.md || {
+            echo '::error file=REFERENCE.md::REFERENCE.md is stale. Run `bundle exec rake strings:generate:reference` and commit the result.'
+            exit 1
+          }
+
   releng-checks:
     name: 'RELENG checks'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `reference` job to `pr_tests.yml` that regenerates REFERENCE.md via `strings:generate:reference` and fails (with a fix-it message) if the committed file has drifted from the manifests' docstrings — so the generated docs can't silently go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)