### PR TITLE
[puppetsync] Re-assert the refreshed pupmod baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ dist
 /pkg
 # Read everything in fixtures
 /spec/fixtures/*
-# Un-ignore hieradata
+# Un-ignore hieradata. The directory itself must be re-included first, otherwise
+# `/spec/fixtures/*` above excludes it and git cannot re-include files within it.
+!/spec/fixtures/hieradata/
 !/spec/fixtures/hieradata/*
 # Except this one, which is auto-generated
 /spec/fixtures/hieradata/hiera.yaml
@@ -25,6 +27,7 @@ dist
 /log
 /doc
 /Gemfile.lock
+/Gemfile.local
 
 ## AI coding assistant-specific configuration
 ## The standard is AGENTS.md

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -13,4 +13,6 @@
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check
+# puppet-lint-strict_indent-check 5.0.0 crashes on some valid manifests
+# (remove when the plugin is fixed upstream)
 --no-strict_indent-check

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,7 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
This patch re-asserts the puppetsync-managed baseline files after
reconciling the templates with the deployed fleet (the templates
now describe the OpenVox-era reality — voxpupuli-test spec_helper,
current dotfiles):

- spec/spec_helper.rb: normalized to the fleet-majority variant
- .puppet-lint.rc: disable the strict_indent check fleet-wide
  (puppet-lint-strict_indent-check 5.0.0 crashes on some valid
  manifests; 16 repos already carried this workaround)
- .gitignore/.pdkignore/.gitattributes/.rspec: majority variants

Gemfiles and workflow files are bootstrap-strategy and are not
touched by this sync (Renovate manages their versions in place).