### PR TITLE
(#107) Wire up the validate_policy parameter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,11 +85,19 @@ source of truth the manifests validate against.
 
 ### Gotchas / non-obvious details
 
-- **`validate_policy` is currently a dead parameter.** It is declared (default
-  `true`) and documented as disabling `$ensure` validation, but nothing in
-  `init.pp` references it — validation is actually gated on the *fact* being
-  populated, not on this flag. Don't assume setting it changes behavior; wire it
-  up if that's the intent.
+- **Validation is gated twice, and the two gates mean different things.** The
+  `if $_ensure and $global_policies_available and $sub_policies_available` block
+  in `init.pp` wraps the `fail()` checks *and* all enforcement — when the
+  `crypto_policy_state` fact is absent the module does nothing at all. The inner
+  `if $validate_policy` wraps only the two `fail()` calls. Don't collapse them:
+  gating the outer block on `validate_policy` would turn the flag into "do
+  nothing", which is the opposite of what it means.
+- **The fact is a pre-catalog snapshot.** `crypto_policy_state` is gathered
+  before the catalog is applied, so it cannot see policies installed during the
+  same run. `custom_subpolicies` keys are merged into `sub_policies_available`
+  to work around this for subpolicies this module declares; global policies and
+  externally-provided subpolicies have no such workaround, which is what
+  `validate_policy => false` is for.
 - This module does **not** depend on `simp/simplib` and uses **no**
   `simp_options::*` lookup seam — unlike most SIMP modules it is essentially
   standalone. Don't add `simplib::lookup` defaults by reflex.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Sep 01 2026 Hazel Caballero <hazel@sicura.us> - 3.1.0
+- Wire up the `validate_policy` parameter, which was declared and documented
+  but never referenced. Setting it to `false` now skips validating `$ensure`
+  against the `crypto_policy_state` fact, for policies that are provided during
+  the same Puppet run that applies them.
+
 * Mon Aug 24 2026 Steven Pritchard <steve@sicura.us> - 3.0.1
 - [puppetsync] Update metadata.json dependency ranges from the Forge
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -92,7 +92,17 @@ Default value: `{}`
 
 Data type: `Boolean`
 
-Disables validation of the `$ensure` parameter prior to application
+Validates the global policy and subpolicies in `$ensure` against those
+reported by the `crypto_policy_state` fact prior to application
+
+* Set this to `false` if the policies you are enforcing are provided during
+  the same Puppet run that applies them. The fact is gathered before the
+  catalog is applied, so policies installed by a package or by another
+  module are not yet visible to it and would otherwise fail validation.
+
+* WARNING: With validation disabled, an invalid policy is not caught at
+  compile time. `update-crypto-policies` fails when the catalog is applied
+  instead.
 
 Default value: `true`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,17 @@
 #         key_size = 4096
 #       ensure: present
 # @param validate_policy
-#   Disables validation of the `$ensure` parameter prior to application
+#   Validates the global policy and subpolicies in `$ensure` against those
+#   reported by the `crypto_policy_state` fact prior to application
+#
+#   * Set this to `false` if the policies you are enforcing are provided during
+#     the same Puppet run that applies them. The fact is gathered before the
+#     catalog is applied, so policies installed by a package or by another
+#     module are not yet visible to it and would otherwise fail validation.
+#
+#   * WARNING: With validation disabled, an invalid policy is not caught at
+#     compile time. `update-crypto-policies` fails when the catalog is applied
+#     instead.
 #
 # @param force_fips_override
 #   Set this to indicate that you wish to force the system into the mode
@@ -111,23 +121,29 @@ class crypto_policy (
   )
 
   if $_ensure and $global_policies_available and $sub_policies_available {
-    unless $_global_policy in $global_policies_available {
-      $_available_policies = join($global_policies_available,"', '")
+    # The fact is gathered before the catalog is applied, so it cannot see
+    # policies that this run installs. Users providing policies out of band can
+    # set $validate_policy to false and let update-crypto-policies do the
+    # checking at apply time instead.
+    if $validate_policy {
+      unless $_global_policy in $global_policies_available {
+        $_available_policies = join($global_policies_available,"', '")
 
-      if $ensure == $_ensure {
-        $ensure_message = $ensure
-      } else {
-        $ensure_message = "${ensure}, overridden to ${_ensure}"
+        if $ensure == $_ensure {
+          $ensure_message = $ensure
+        } else {
+          $ensure_message = "${ensure}, overridden to ${_ensure}"
+        }
+
+        fail("${module_name}::ensure (${ensure_message}) must be one of '${_available_policies}'")
       }
 
-      fail("${module_name}::ensure (${ensure_message}) must be one of '${_available_policies}'")
-    }
-
-    unless $_sub_policies.empty or ($_sub_policies - $sub_policies_available).empty {
-      $_available_sub_policies = join($sub_policies_available, "', '")
-      # Any sub policies not available to use will be displayed back to the user
-      $_unknown_sub_policies = join(($_sub_policies - $sub_policies_available), "', '")
-      fail("${module_name}::ensure unknown sub_policies (${$_unknown_sub_policies}) must be one of '${_available_sub_policies}'")
+      unless $_sub_policies.empty or ($_sub_policies - $sub_policies_available).empty {
+        $_available_sub_policies = join($sub_policies_available, "', '")
+        # Any sub policies not available to use will be displayed back to the user
+        $_unknown_sub_policies = join(($_sub_policies - $sub_policies_available), "', '")
+        fail("${module_name}::ensure unknown sub_policies (${$_unknown_sub_policies}) must be one of '${_available_sub_policies}'")
+      }
     }
 
     class { 'crypto_policy::update':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-crypto_policy",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "SIMP Team",
   "summary": "Manage, and provide information about, the system-wide crypto policies",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -311,6 +311,67 @@ describe 'crypto_policy' do
           it { is_expected.not_to compile }
         end
 
+        context 'with validation disabled' do
+          context 'with ensure set to a non-existent global policy' do
+            let(:params) do
+              {
+                ensure: 'FAKE',
+                validate_policy: false,
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it {
+              is_expected.to create_file('/etc/crypto-policies/config').with_content(
+                <<~CONTENT,
+                  FAKE
+                CONTENT
+              ).that_notifies('Class[crypto_policy::update]')
+            }
+
+            it { is_expected.to create_exec('update global crypto policy') }
+          end
+
+          context 'with ensure set to a non-existent subpolicy' do
+            let(:params) do
+              {
+                ensure: 'DEFAULT:FAKE',
+                validate_policy: false,
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it {
+              is_expected.to create_file('/etc/crypto-policies/config').with_content(
+                <<~CONTENT,
+                  DEFAULT:FAKE
+                CONTENT
+              ).that_notifies('Class[crypto_policy::update]')
+            }
+          end
+
+          context 'with a valid policy' do
+            let(:params) do
+              {
+                ensure: 'DEFAULT:NO-SHA1',
+                validate_policy: false,
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it {
+              is_expected.to create_file('/etc/crypto-policies/config').with_content(
+                <<~CONTENT,
+                  DEFAULT:NO-SHA1
+                CONTENT
+              ).that_notifies('Class[crypto_policy::update]')
+            }
+          end
+        end
+
         context 'with the system in FIPS mode' do
           let(:fips_enabled) { true }
 


### PR DESCRIPTION
Closes #107. `validate_policy` was declared and documented but never referenced, so setting it to `false` did nothing — validation ran regardless. This gates the two `fail()` calls on it so the parameter does what its docstring promises, which matters because the `crypto_policy_state` fact is a pre-catalog snapshot and cannot see policies installed during the same run (`custom_subpolicies` keys are already merged in to work around this, but global policies and externally-provided subpolicies have no such escape). The checks stay inside the existing fact-populated guard rather than replacing it, since that outer block also wraps enforcement — gating it on `validate_policy` would skip applying the policy too. Docstring, REFERENCE.md, and the AGENTS.md gotcha are updated to match, and specs cover the disabled path.